### PR TITLE
Don't allow Seeldier's minions to cap

### DIFF
--- a/pluginV1/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
+++ b/pluginV1/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
@@ -198,7 +198,7 @@ Rage_CloneAttack(const String:ability_name[],index)
 				case 1:
 				{
 					TF2_RemoveAllWeapons(client);
-					weapon=SpawnWeapon(client,"tf_weapon_bottle",191,34,0,"");
+					weapon=SpawnWeapon(client,"tf_weapon_bottle",191,34,0,"68 ; -1");
 					if (IsValidEdict(weapon))
 					{
 						SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon",weapon);


### PR DESCRIPTION
It is way too unbalanced to allow Seeldier's minions to cap.  If Seeldier decides to spawn them on/near the cap, RED will literally lose in a few seconds because of a few AFK/tabbed-out people.  The x6 cap rate given if both Seeldier and Seeman are on the point is definitely enough.  As a note, we're not allowing them to cap, and it's working out perfectly fine (for more than ~4 months).
