### PR TITLE
Fix 1.6.1 subplugin compilation issues

### DIFF
--- a/addons/sourcemod/gamedata/equipwearable.txt
+++ b/addons/sourcemod/gamedata/equipwearable.txt
@@ -11,13 +11,6 @@
 				"mac"		"426"
 			}
 
-			"RemoveWearable"
-			{
-				"windows"	"426"
-				"linux"		"427"
-				"mac"		"427"
-			}
-
 			"IsWearable"
 			{
 				"windows"	"87"

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -501,34 +501,17 @@ stock TF2_IsWearable(wearable)
 	return SDKCall(isWearable, wearable);
 }
 
+// These still exist for compatibility reasons
 stock TF2_RemoveWeaponSlot2(client, slot)
 {
-	decl wearable;
-	new weaponIndex;
-	while((weaponIndex=GetPlayerWeaponSlot(client, slot))!=-1)
-	{
-		wearable=GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearable");
-		if(IsValidEntity(wearable))
-		{
-			TF2_RemoveWearable(client, wearable);
-		}
-
-		wearable=GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearableViewModel");
-		if(IsValidEntity(wearable))
-		{
-			TF2_RemoveWearable(client, wearable);
-		}
-
-		RemovePlayerItem(client, weaponIndex);
-		AcceptEntityInput(weaponIndex, "Kill");
-	}
+	TF2_RemoveWeaponSlot(client, slot);
 }
 
 stock TF2_RemoveAllWeapons2(client)
 {
 	for(new slot=0; slot<=5; slot++)
 	{
-		TF2_RemoveWeaponSlot2(client, slot);
+		TF2_RemoveWeaponSlot(client, slot);
 	}
 }
 /* End temp wearable stocks */


### PR DESCRIPTION
TF2_RemoveWearable is now in SM 1.6.1.  Some builtins were also fixed in SM 1.6.1 (TF2_RemoveWeaponSlot for instance)
