### PR TITLE
Fix 'sound_fail' playing if boss wins

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2501,7 +2501,7 @@ public Action:event_round_end(Handle:event, const String:name[], bool:dontBroadc
 			}
 		}
 
-		if(!bossWin && (RandomSound("sound_fail", sound, sizeof(sound), boss)))
+		if(!bossWin && RandomSound("sound_fail", sound, sizeof(sound), boss))
 		{
 			Debug("Oo La Laaa");
 			EmitSoundToAll(sound);

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2501,7 +2501,7 @@ public Action:event_round_end(Handle:event, const String:name[], bool:dontBroadc
 			}
 		}
 
-		if((GetEventInt(event, "team")!=BossTeam) && (RandomSound("sound_fail", sound, PLATFORM_MAX_PATH, boss)))
+		if(!bossWin && (RandomSound("sound_fail", sound, sizeof(sound), boss)))
 		{
 			Debug("Oo La Laaa");
 			EmitSoundToAll(sound);

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2501,8 +2501,9 @@ public Action:event_round_end(Handle:event, const String:name[], bool:dontBroadc
 			}
 		}
 
-		if(RandomSound("sound_fail", sound, sizeof(sound), boss))
+		if((GetEventInt(event, "team")!=BossTeam) && (RandomSound("sound_fail", sound, PLATFORM_MAX_PATH, boss)))
 		{
+			Debug("Oo La Laaa");
 			EmitSoundToAll(sound);
 			EmitSoundToAll(sound);
 		}


### PR DESCRIPTION
Adding check to ensure 'sound_fail' only plays if the winning team isn't the boss team, or if the round ends in a stalemate.