### PR TITLE
Debug for 'special_dropprop'

### DIFF
--- a/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
@@ -765,16 +765,21 @@ public Action:OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcas
 		
 			decl String:model[PLATFORM_MAX_PATH];
 			FF2_GetAbilityArgumentString(boss, this_plugin_name, "special_dropprop", 1, model, sizeof(model));
-			if(model[0] != '\0') // NEVER fire special_dropprop sequence if string is blank
+			if(model[0]!='\0') // NEVER fire special_dropprop sequence if string is blank
 			{
-				Debug("Model specified is '%s'", model);
 				if(!IsModelPrecached(model)) // Check to see if 'mod_precache' precached the models properly or not
 				{
-					Debug("Model '%s' is NOT precached! precaching model", model);
+					if(!FileExists(model, true))
+					{
+						LogError("[FF2] Warning: Model '%s' does NOT exist!", model);
+						return Plugin_Continue;
+					}
+				
+					new String:bossname[256];
+					FF2_GetBossSpecial(boss, bossname, sizeof(bossname));
+					LogError("[FF2] Warning: Model '%s' is NOT precached! Please check \"mod_precache\" on %s", model, bossname);
 					PrecacheModel(model);
 				}
-				else
-					Debug("Model '%s' is precached!", model);
 					
 				if(FF2_GetAbilityArgument(boss, this_plugin_name, "special_dropprop", 3, 0))
 				{

--- a/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
@@ -758,6 +758,11 @@ public Action:OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcas
 	{
 		if(FF2_HasAbility(boss, this_plugin_name, "special_dropprop"))
 		{
+			if(!attacker || !client || attacker==client) // Somehow this is needed for special_dropprop
+			{
+				return Plugin_Continue;
+			}
+		
 			decl String:model[PLATFORM_MAX_PATH];
 			FF2_GetAbilityArgumentString(boss, this_plugin_name, "special_dropprop", 1, model, sizeof(model));
 			if(model[0] != '\0') // NEVER fire special_dropprop sequence if string is blank

--- a/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
@@ -758,30 +758,42 @@ public Action:OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcas
 	{
 		if(FF2_HasAbility(boss, this_plugin_name, "special_dropprop"))
 		{
-			if(FF2_GetAbilityArgument(boss, this_plugin_name, "special_dropprop", 3, 0))
+			decl String:model[PLATFORM_MAX_PATH];
+			FF2_GetAbilityArgumentString(boss, this_plugin_name, "special_dropprop", 1, model, sizeof(model));
+			if(model[0] != '\0') // NEVER fire special_dropprop sequence if string is blank
 			{
-				CreateTimer(0.01, Timer_RemoveRagdoll, GetEventInt(event, "userid"));
-			}
-
-			new prop=CreateEntityByName("prop_physics_override");
-			if(IsValidEntity(prop))
-			{
-				decl String:model[PLATFORM_MAX_PATH];
-				FF2_GetAbilityArgumentString(boss, this_plugin_name, "special_dropprop", 1, model, sizeof(model));
-				SetEntityModel(prop, model);
-				SetEntityMoveType(prop, MOVETYPE_VPHYSICS);
-				SetEntProp(prop, Prop_Send, "m_CollisionGroup", 1);
-				SetEntProp(prop, Prop_Send, "m_usSolidFlags", 16);
-				DispatchSpawn(prop);
-
-				new Float:position[3];
-				GetEntPropVector(client, Prop_Send, "m_vecOrigin", position);
-				position[2]+=20;
-				TeleportEntity(prop, position, NULL_VECTOR, NULL_VECTOR);
-				new Float:duration=FF2_GetAbilityArgumentFloat(boss, this_plugin_name, "special_dropprop", 2, 0.0);
-				if(duration>0.5)
+				Debug("Model specified is '%s'", model)
+				if(!IsModelPrecached(model)) // Check to see if 'mod_precache' precached the models properly or not
 				{
-					CreateTimer(duration, Timer_RemoveEntity, EntIndexToEntRef(prop));
+					Debug("Model '%s' is NOT precached! precaching model", model);
+					PrecacheModel(model);
+				}
+				else
+					Debug("Model '%s' is precached!", model);
+					
+				if(FF2_GetAbilityArgument(boss, this_plugin_name, "special_dropprop", 3, 0))
+				{
+					CreateTimer(0.01, Timer_RemoveRagdoll, GetEventInt(event, "userid"));
+				}
+					
+				new prop=CreateEntityByName("prop_physics_override");
+				if(IsValidEntity(prop))
+				{		
+					SetEntityModel(prop, model);
+					SetEntityMoveType(prop, MOVETYPE_VPHYSICS);
+					SetEntProp(prop, Prop_Send, "m_CollisionGroup", 1);
+					SetEntProp(prop, Prop_Send, "m_usSolidFlags", 16);
+					DispatchSpawn(prop);
+
+					new Float:position[3];
+					GetEntPropVector(client, Prop_Send, "m_vecOrigin", position);
+					position[2]+=20;
+					TeleportEntity(prop, position, NULL_VECTOR, NULL_VECTOR);
+					new Float:duration=FF2_GetAbilityArgumentFloat(boss, this_plugin_name, "special_dropprop", 2, 0.0);
+					if(duration>0.5)
+					{
+						CreateTimer(duration, Timer_RemoveEntity, EntIndexToEntRef(prop));
+					}
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_1st_set_abilities.sp
@@ -762,7 +762,7 @@ public Action:OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcas
 			FF2_GetAbilityArgumentString(boss, this_plugin_name, "special_dropprop", 1, model, sizeof(model));
 			if(model[0] != '\0') // NEVER fire special_dropprop sequence if string is blank
 			{
-				Debug("Model specified is '%s'", model)
+				Debug("Model specified is '%s'", model);
 				if(!IsModelPrecached(model)) // Check to see if 'mod_precache' precached the models properly or not
 				{
 					Debug("Model '%s' is NOT precached! precaching model", model);


### PR DESCRIPTION
* Rearranged 'special_dropprop' so that it will only fire if model path string is NOT blank
* Check if model was precached properly, else precaches the model immediately to prevent server crashes
* Debug lines for 'model' string and to report whether model was precached properly or not.
