### PR TITLE
Fix PreAbility.

### DIFF
--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -401,7 +401,7 @@ native bool:FF2_Debug();
  *							3 - In use
  * @return				Plugin_Stop can not prevent the ability. Use FF2_PreAbility with enabled=false
  */
-forward FF2_PreAbility(boss, const String:pluginName[], const String:abilityName[], slot, status, &bool:enabled);
+forward FF2_PreAbility(boss, const String:pluginName[], const String:abilityName[], slot, &bool:enabled);
 forward Action:FF2_OnAbility(boss, const String:pluginName[], const String:abilityName[], slot, status);
 
 /**

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -401,7 +401,7 @@ native bool:FF2_Debug();
  *							3 - In use
  * @return				Plugin_Stop can not prevent the ability. Use FF2_PreAbility with enabled=false
  */
-forward FF2_PreAbility(boss, const String:pluginName[], const String:abilityName[], slot, status, &enabled=true);
+forward FF2_PreAbility(boss, const String:pluginName[], const String:abilityName[], slot, status, &bool:enabled);
 forward Action:FF2_OnAbility(boss, const String:pluginName[], const String:abilityName[], slot, status);
 
 /**


### PR DESCRIPTION
extra/freak_fortress_2.inc(404) : error 059: function argument may not have a default value (variable "enabled")
^ and the fact it was causing memory corruption when modifying the enabled var.