### PR TITLE
FIx death effects triggering on inactive rounds + Boss disconnection action cvar.

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -4434,7 +4434,7 @@ public OnClientDisconnect(client)
 					
 					CreateTimer(0.1, MakeBoss);
 					
-					CPrintToChat(Boss[boss], "{olive}[FF2] %t", "Replace Disconnected Boss");
+					CPrintToChat(Boss[boss], "{olive}[FF2]{default} %t", "Replace Disconnected Boss");
 					CPrintToChatAll("{olive}[FF2]{default} %t", "Boss Disconnected", client, Boss[boss]);
 				}
 			}

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -139,7 +139,7 @@ new Handle:cvarGoombaRebound;
 new Handle:cvarBossRTD;
 new Handle:cvarUpdater;
 new Handle:cvarDebug;
-
+new Handle:cvarPreroundBossDisconnect;
 new Handle:FF2Cookies;
 
 new Handle:jumpHUD;
@@ -994,6 +994,7 @@ public OnPluginStart()
 	cvarLastPlayerGlow=CreateConVar("ff2_last_player_glow", "1", "0-Don't outline the last player, 1-Outline the last player alive", FCVAR_PLUGIN, true, 0.0, true, 1.0);
 	cvarBossTeleporter=CreateConVar("ff2_boss_teleporter", "0", "-1 to disallow all bosses from using teleporters, 0 to use TF2 logic, 1 to allow all bosses", FCVAR_PLUGIN, true, -1.0, true, 1.0);
 	cvarBossSuicide=CreateConVar("ff2_boss_suicide", "0", "Allow the boss to suicide after the round starts?", FCVAR_PLUGIN, true, 0.0, true, 1.0);
+	cvarPreroundBossDisconnect=CreateConVar("ff2_preround_boss_disconnect_action", "1", "Action when a boss disconnects before the round starts. 0 - End the round normally, 1 - Replace disconnected boss with the next available player", FCVAR_PLUGIN, true, 0.0, true, 1.0);
 	cvarCaberDetonations=CreateConVar("ff2_caber_detonations", "5", "Amount of times somebody can detonate the Ullapool Caber", FCVAR_PLUGIN);
 	cvarShieldCrits=CreateConVar("ff2_shield_crits", "0", "0 to disable grenade launcher crits when equipping a shield, 1 for minicrits, 2 for crits", FCVAR_PLUGIN, true, 0.0, true, 2.0);
 	cvarGoombaDamage=CreateConVar("ff2_goomba_damage", "0.05", "How much the Goomba damage should be multipled by when goomba stomping the boss (requires Goomba Stomp)", FCVAR_PLUGIN, true, 0.01, true, 1.0);
@@ -4405,9 +4406,41 @@ public OnClientPutInServer(client)
 
 public OnClientDisconnect(client)
 {
-	if(Enabled && IsClientInGame(client) && IsPlayerAlive(client) && CheckRoundState()==1)
+	if(Enabled)
 	{
-		CreateTimer(0.1, CheckAlivePlayers);
+		if(IsBoss(client) && cvarPreroundBossDisconnect)
+		{
+			if (CheckRoundState()==1)
+			{
+				ForceTeamWin(OtherTeam);
+			}
+			
+			if (CheckRoundState()<=0)
+			{
+				new bool:omit[MaxClients+1];
+				Boss[0]=GetClientWithMostQueuePoints(omit);
+				omit[Boss[0]]=true;
+				
+				if (IsValidClient(Boss[0]))
+				{	
+					SetEntProp(Boss[0], Prop_Send, "m_lifeState", 2);
+					ChangeClientTeam(Boss[0], BossTeam);
+					SetEntProp(Boss[0], Prop_Send, "m_lifeState", 0);
+					TF2_RespawnPlayer(Boss[0]);
+					
+					CreateTimer(0.1, MakeBoss);
+					
+					CPrintToChat(Boss[0], "{olive}[FF2] %t", "Disconnected Boss Replaced Pre-Round");
+				}
+			}
+			
+			CPrintToChatAll("{olive}[FF2]{default} %t", "Boss Disconnected");
+		}
+		
+		if(IsClientInGame(client) && IsPlayerAlive(client) && CheckRoundState()==1)
+		{
+			CreateTimer(0.1, CheckAlivePlayers);
+		}
 	}
 }
 
@@ -5524,7 +5557,7 @@ public Action:Timer_DrawGame(Handle:timer)
 
 public Action:event_hurt(Handle:event, const String:name[], bool:dontBroadcast)
 {
-	if(!Enabled)
+	if(!Enabled || CheckRoundState()!=1)
 	{
 		return Plugin_Continue;
 	}

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -4413,19 +4413,19 @@ public OnClientDisconnect(client)
 		if(IsBoss(client))
 		{
 		
-			if (CheckRoundState()==1)
+			if(CheckRoundState()==1)
 			{
 				ForceTeamWin(OtherTeam);
 			}
 			
-			if (GetConVarBool(cvarPreroundBossDisconnect) && CheckRoundState()<=0)
+			if(GetConVarBool(cvarPreroundBossDisconnect) && CheckRoundState()==0)
 			{
 				new bool:omit[MaxClients+1];
 				new boss=GetBossIndex(client);
 				Boss[boss]=GetClientWithMostQueuePoints(omit);
 				omit[Boss[boss]]=true;
 				
-				if (IsValidClient(Boss[boss]))
+				if(IsValidClient(Boss[boss]))
 				{	
 					SetEntProp(Boss[boss], Prop_Send, "m_lifeState", 2);
 					ChangeClientTeam(Boss[boss], BossTeam);

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -4418,9 +4418,12 @@ public OnClientDisconnect(client)
 				ForceTeamWin(OtherTeam);
 			}
 			
-			if(GetConVarBool(cvarPreroundBossDisconnect) && CheckRoundState()==0)
+			if(GetConVarBool(cvarPreroundBossDisconnect) && !CheckRoundState())
 			{
 				new bool:omit[MaxClients+1];
+			
+				omit[client]=true;
+				
 				new boss=GetBossIndex(client);
 				Boss[boss]=GetClientWithMostQueuePoints(omit);
 				omit[Boss[boss]]=true;

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -140,6 +140,7 @@ new Handle:cvarBossRTD;
 new Handle:cvarUpdater;
 new Handle:cvarDebug;
 new Handle:cvarPreroundBossDisconnect;
+
 new Handle:FF2Cookies;
 
 new Handle:jumpHUD;
@@ -994,7 +995,7 @@ public OnPluginStart()
 	cvarLastPlayerGlow=CreateConVar("ff2_last_player_glow", "1", "0-Don't outline the last player, 1-Outline the last player alive", FCVAR_PLUGIN, true, 0.0, true, 1.0);
 	cvarBossTeleporter=CreateConVar("ff2_boss_teleporter", "0", "-1 to disallow all bosses from using teleporters, 0 to use TF2 logic, 1 to allow all bosses", FCVAR_PLUGIN, true, -1.0, true, 1.0);
 	cvarBossSuicide=CreateConVar("ff2_boss_suicide", "0", "Allow the boss to suicide after the round starts?", FCVAR_PLUGIN, true, 0.0, true, 1.0);
-	cvarPreroundBossDisconnect=CreateConVar("ff2_preround_boss_disconnect_action", "1", "Action when a boss disconnects before the round starts. 0 - End the round normally, 1 - Replace disconnected boss with the next available player", FCVAR_PLUGIN, true, 0.0, true, 1.0);
+	cvarPreroundBossDisconnect=CreateConVar("ff2_replace_disconnected_boss", "1", "If a boss disconnects before the round starts, use the next player in line instead? 0 - No, 1 - Yes", FCVAR_PLUGIN, true, 0.0, true, 1.0);
 	cvarCaberDetonations=CreateConVar("ff2_caber_detonations", "5", "Amount of times somebody can detonate the Ullapool Caber", FCVAR_PLUGIN);
 	cvarShieldCrits=CreateConVar("ff2_shield_crits", "0", "0 to disable grenade launcher crits when equipping a shield, 1 for minicrits, 2 for crits", FCVAR_PLUGIN, true, 0.0, true, 2.0);
 	cvarGoombaDamage=CreateConVar("ff2_goomba_damage", "0.05", "How much the Goomba damage should be multipled by when goomba stomping the boss (requires Goomba Stomp)", FCVAR_PLUGIN, true, 0.01, true, 1.0);
@@ -4408,33 +4409,35 @@ public OnClientDisconnect(client)
 {
 	if(Enabled)
 	{
-		if(IsBoss(client) && cvarPreroundBossDisconnect)
+	
+		if(IsBoss(client))
 		{
+		
 			if (CheckRoundState()==1)
 			{
 				ForceTeamWin(OtherTeam);
 			}
 			
-			if (CheckRoundState()<=0)
+			if (GetConVarBool(cvarPreroundBossDisconnect) && CheckRoundState()<=0)
 			{
 				new bool:omit[MaxClients+1];
-				Boss[0]=GetClientWithMostQueuePoints(omit);
-				omit[Boss[0]]=true;
+				new boss=GetBossIndex(client);
+				Boss[boss]=GetClientWithMostQueuePoints(omit);
+				omit[Boss[boss]]=true;
 				
-				if (IsValidClient(Boss[0]))
+				if (IsValidClient(Boss[boss]))
 				{	
-					SetEntProp(Boss[0], Prop_Send, "m_lifeState", 2);
-					ChangeClientTeam(Boss[0], BossTeam);
-					SetEntProp(Boss[0], Prop_Send, "m_lifeState", 0);
-					TF2_RespawnPlayer(Boss[0]);
+					SetEntProp(Boss[boss], Prop_Send, "m_lifeState", 2);
+					ChangeClientTeam(Boss[boss], BossTeam);
+					SetEntProp(Boss[boss], Prop_Send, "m_lifeState", 0);
+					TF2_RespawnPlayer(Boss[boss]);
 					
 					CreateTimer(0.1, MakeBoss);
 					
-					CPrintToChat(Boss[0], "{olive}[FF2] %t", "Disconnected Boss Replaced Pre-Round");
+					CPrintToChat(Boss[boss], "{olive}[FF2] %t", "Replace Disconnected Boss");
+					CPrintToChatAll("{olive}[FF2]{default} %t", "Boss Disconnected", client, Boss[boss]);
 				}
 			}
-			
-			CPrintToChatAll("{olive}[FF2]{default} %t", "Boss Disconnected");
 		}
 		
 		if(IsClientInGame(client) && IsPlayerAlive(client) && CheckRoundState()==1)

--- a/addons/sourcemod/translations/freak_fortress_2.phrases.txt
+++ b/addons/sourcemod/translations/freak_fortress_2.phrases.txt
@@ -332,9 +332,10 @@
 	}
 	"Boss Disconnected"
 	{
-		"en"	"The boss has disconnected!"
+		"#format" "{1:N}, {2:N}"
+		"en"	"{1} has disconnected and now {2} is the new boss!"
 	}
-	"Disconnected Boss Replaced Pre-Round"
+	"Replace Disconnected Boss"
 	{
 		"en"	"Surprise! You are now the boss!"
 	}

--- a/addons/sourcemod/translations/freak_fortress_2.phrases.txt
+++ b/addons/sourcemod/translations/freak_fortress_2.phrases.txt
@@ -330,6 +330,14 @@
 	{
 		"en"	"You are not allowed to suicide before the round starts!"
 	}
+	"Boss Disconnected"
+	{
+		"en"	"The boss has disconnected!"
+	}
+	"Disconnected Boss Replaced Pre-Round"
+	{
+		"en"	"Surprise! You are now the boss!"
+	}
 	"Backstab"
 	{
 		"en"	"You just backstabbed the boss!"


### PR DESCRIPTION
* Fix death effects triggering when a round is over
* cvar to determine what action should be taken when a boss disconnects
before the round starts