### PR TITLE
Make backstabs/market gardens/goomba stomp notifications less generic...

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -6360,6 +6360,7 @@ public Action:OnStomp(attacker, victim, &Float:damageMultiplier, &Float:damageBo
 		new String:bossName[768];
 		new boss=FF2_GetBossIndex(victim);
 		FF2_GetBossSpecial(boss, bossName, sizeof(bossName));
+		
 		damageMultiplier=GoombaDamage;
 		JumpPower=reboundPower;
 		PrintHintText(victim, "%t", "Boss Goomba Stomped");

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -5828,6 +5828,9 @@ public Action:OnTakeDamage(client, &attacker, &inflictor, &Float:damage, &damage
 		new boss=GetBossIndex(client);
 		if(boss!=-1)
 		{
+			new String:bossName[768];
+			FF2_GetBossSpecial(boss, bossName, sizeof(bossName));
+			
 			if(attacker<=MaxClients)
 			{
 				new bool:bIsTelefrag, bool:bIsBackstab;
@@ -6043,7 +6046,7 @@ public Action:OnTakeDamage(client, &attacker, &inflictor, &Float:damage, &damage
 								Marketed[client]++;
 							}
 
-							PrintHintText(attacker, "%t", "Market Gardener");  //You just market-gardened the boss!
+							PrintHintText(attacker, "%t", "Market Gardener", bossName);  //You just market-gardened the boss!
 							PrintHintText(client, "%t", "Market Gardened");  //You just got market-gardened!
 
 							EmitSoundToClient(attacker, "player/doubledonk.wav", _, _, _, _, 0.6, _, _, position, _, false);
@@ -6170,7 +6173,7 @@ public Action:OnTakeDamage(client, &attacker, &inflictor, &Float:damage, &damage
 
 					if(!(FF2flags[attacker] & FF2FLAG_HUDDISABLED))
 					{
-						PrintHintText(attacker, "%t", "Backstab");
+						PrintHintText(attacker, "%t", "Backstab", bossName);
 					}
 
 					if(!(FF2flags[client] & FF2FLAG_HUDDISABLED))
@@ -6348,16 +6351,19 @@ public Action:OnStomp(attacker, victim, &Float:damageMultiplier, &Float:damageBo
 		}
 		damageMultiplier=900.0;
 		JumpPower=0.0;
-		PrintHintText(victim, "Ouch!  Watch your head!");
-		PrintHintText(attacker, "You just goomba stomped somebody!");
+		PrintHintText(victim, "%t", "Player Goomba Stomped");
+		PrintHintText(attacker, "%t", "Boss Goomba Stomps", victim);
 		return Plugin_Changed;
 	}
 	else if(IsBoss(victim))
 	{
+		new String:bossName[768];
+		new boss=FF2_GetBossIndex(victim);
+		FF2_GetBossSpecial(boss, bossName, sizeof(bossName));
 		damageMultiplier=GoombaDamage;
 		JumpPower=reboundPower;
-		PrintHintText(victim, "You were just goomba stomped!");
-		PrintHintText(attacker, "You just goomba stomped the boss!");
+		PrintHintText(victim, "%t", "Boss Goomba Stomped");
+		PrintHintText(attacker, "%t", "Player Goomba Stomps", bossName);
 		UpdateHealthBar();
 		return Plugin_Changed;
 	}

--- a/addons/sourcemod/translations/freak_fortress_2.phrases.txt
+++ b/addons/sourcemod/translations/freak_fortress_2.phrases.txt
@@ -341,7 +341,8 @@
 	}
 	"Backstab"
 	{
-		"en"	"You just backstabbed the boss!"
+		"#format"	"{1:s}"
+		"en"	"You just backstabbed {1}!"
 	}
 	"Backstabbed"
 	{
@@ -349,7 +350,8 @@
 	}
 	"Market Gardener"
 	{
-		"en"	"You just market-gardened the boss!"
+		"#format"	"{1:s}"
+		"en"	"You just market-gardened {1}!"
 	}
 	"Market Gardened"
 	{
@@ -359,5 +361,23 @@
 	{
 		"#format"	"{1:i}"
 		"en"		"You have {1} detonations left!"
+	}
+	"Boss Goomba Stomps"
+	{
+		"#format"	"{1:N}"
+		"en"	"You just goomba stomped {1}!"	
+	}
+	"Boss Goomba Stomped"
+	{
+		"en"	"You were just goomba stomped!"
+	}
+	"Player Goomba Stomps"
+	{
+		"#format"	"{1:s}"
+		"en"	"You just goomba stomped {1}!"
+	}
+	"Player Goomba Stomped"
+	{
+		"en"	"Ouch!  Watch your head!"
 	}
 }


### PR DESCRIPTION
..and actually show the boss's name

Also, why hasn't the goomba stomp notifications text been moved to the
translations file already?