### PR TITLE
Goomba Stomp does not Update Healthbar

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -6554,10 +6554,15 @@ public Action:OnStomp(attacker, victim, &Float:damageMultiplier, &Float:damageBo
 		JumpPower=reboundPower;
 		PrintHintText(victim, "You were just goomba stomped!");
 		PrintHintText(attacker, "You just goomba stomped the boss!");
-		UpdateHealthBar();
+		RequestFrame(Timer_GoombaUpdateHealthBar, 0);
 		return Plugin_Changed;
 	}
 	return Plugin_Continue;
+}
+
+public Timer_GoombaUpdateHealthBar(any:data)
+{
+	UpdateHealthBar();
 }
 
 public Action:RTD_CanRollDice(client)


### PR DESCRIPTION
When I goomba stomp someone on my server, it never updated the healthbar. The hale needed to be damaged again to update it. This fixes the "issue".