### PR TITLE
v1.36 Backport (3/9): Cancel out "meedic" voice/text callout while activating RAGE

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -5244,6 +5244,7 @@ public Action:OnCallForMedic(client, const String:command[], args)
 			FF2flags[Boss[boss]]&=~FF2FLAG_TALKING;
 		}
 		emitRageSound[boss]=true;
+		return Plugin_Handled;
 	}
 	return Plugin_Continue;
 }


### PR DESCRIPTION
Cancel out "meedic" callout when activating RAGE