### PR TITLE
v1.36 Backport (4/9): Introduce SetBossTeam (public analogue)

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2254,20 +2254,7 @@ public Action:OnRoundStart(Handle:event, const String:name[], bool:dontBroadcast
 		}
 	}
 
-	if(blueBoss)
-	{
-		SetTeamScore(_:TFTeam_Red, GetTeamScore(OtherTeam));
-		SetTeamScore(_:TFTeam_Blue, GetTeamScore(BossTeam));
-		OtherTeam=_:TFTeam_Red;
-		BossTeam=_:TFTeam_Blue;
-	}
-	else
-	{
-		SetTeamScore(_:TFTeam_Red, GetTeamScore(BossTeam));
-		SetTeamScore(_:TFTeam_Blue, GetTeamScore(OtherTeam));
-		OtherTeam=_:TFTeam_Blue;
-		BossTeam=_:TFTeam_Red;
-	}
+	SetBossTeam(blueBoss ? TFTeam_Blue : TFTeam_Red);
 
 	playing=0;
 	for(new client=1; client<=MaxClients; client++)
@@ -2436,6 +2423,14 @@ public Action:OnRoundStart(Handle:event, const String:name[], bool:dontBroadcast
 	healthcheckused=0;
 	firstBlood=true;
 	return Plugin_Continue;
+}
+
+public SetBossTeam(TFTeam:bossTeam)
+{
+	SetTeamScore(_:(bossTeam==TFTeam_Blue ? TFTeam_Red : TFTeam_Blue), GetTeamScore(OtherTeam));
+	SetTeamScore(_:bossTeam, GetTeamScore(BossTeam));
+	OtherTeam=_:(bossTeam==TFTeam_Blue ? TFTeam_Red : TFTeam_Blue);
+	BossTeam=_:bossTeam;
 }
 
 public Action:Timer_EnableCap(Handle:timer)


### PR DESCRIPTION
Subplugins can use reflection to use it if necessary. Otherwise, used internally to tidy up (and remove duplicate) code relating to setting the boss team, and making it easier to maintain.

SUBPLUGIN MAKERS, please remember to change the entity team numbers of the following if reflectively calling the analogue for vsh_ and ph_ maps, for a true team switch. Not necessary in arena_ or any other maps:
* info_player_teamspawn (reverse spawn locations)
* obj_sentrygun (world sentries)
* obj_dispenser (world dispensers)
* obj_teleporter (world teleporters)
* filter_activator_tfteam (some maps normally slays reds, teleports blues, etc)