### PR TITLE
Don't forget MusicTimer[0]!

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2922,7 +2922,7 @@ StopMusic(client=0)
 {
 	if(client<=0)  //Stop music for all clients
 	{
-		for(client=1; client<=MaxClients; client++)
+		for(client=0; client<=MaxClients; client++)
 		{
 			if(IsValidClient(client))
 			{


### PR DESCRIPTION
My English is bad. Sorry :(

Because MusicTimer[0] also used.
Line 2807: CreateTimer(2.0, Timer_PlayBGM, 0, TIMER_FLAG_NO_MAPCHANGE);

My server had bug. It was play BGM when still playing. and loop, loop.... (Ahhh.. my ear!)
But after this commit, it fixed.
  