### PR TITLE
Fixed BGM doesn't loop.(what?)

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -1540,7 +1540,7 @@ public DisableFF2()
 			}
 		}
 
-		if(MusicTimer[client]!=INVALID_HANDLE)
+		if(MusicTimer[client])
 		{
 			KillTimer(MusicTimer[client]);
 			MusicTimer[client]=INVALID_HANDLE;
@@ -2891,7 +2891,7 @@ public Action:Timer_PrepareBGM(Handle:timer, any:userid)
 				}
 				else
 				{
-					if(MusicTimer[client]!=INVALID_HANDLE)
+					if(MusicTimer[client])
 					{
 						KillTimer(MusicTimer[client]);
 						MusicTimer[client]=INVALID_HANDLE;
@@ -2900,7 +2900,7 @@ public Action:Timer_PrepareBGM(Handle:timer, any:userid)
 				continue;
 			}
 
-			if(MusicTimer[client]!=INVALID_HANDLE)
+			if(MusicTimer[client])
 			{
 				KillTimer(MusicTimer[client]);
 				MusicTimer[client]=INVALID_HANDLE;
@@ -2915,7 +2915,7 @@ public Action:Timer_PrepareBGM(Handle:timer, any:userid)
 		}
 		else
 		{
-			if(MusicTimer[client]!=INVALID_HANDLE)
+			if(MusicTimer[client])
 			{
 				KillTimer(MusicTimer[client]);
 				MusicTimer[client]=INVALID_HANDLE;
@@ -3016,7 +3016,7 @@ StopMusic(client=0, bool:permanent=false)
 				StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 			}
 
-			if(MusicTimer[client]!=INVALID_HANDLE)
+			if(MusicTimer[client])
 			{
 				KillTimer(MusicTimer[client]);
 				MusicTimer[client]=INVALID_HANDLE;
@@ -3033,7 +3033,7 @@ StopMusic(client=0, bool:permanent=false)
 		StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 		StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 
-		if(MusicTimer[client]!=INVALID_HANDLE)
+		if(MusicTimer[client])
 		{
 			KillTimer(MusicTimer[client]);
 			MusicTimer[client]=INVALID_HANDLE;

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -4525,6 +4525,12 @@ public OnClientDisconnect(client)
 	FF2flags[client]=0;
 	Damage[client]=0;
 	uberTarget[client]=-1;
+	
+	if(MusicTimer[client]!=INVALID_HANDLE)
+	{
+		KillTimer(MusicTimer[client]);
+		MusicTimer[client]=INVALID_HANDLE;
+	}
 }
 
 public Action:OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast)

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2896,8 +2896,8 @@ public Action:Timer_PrepareBGM(Handle:timer, any:userid)
 						KillTimer(MusicTimer[client]);
 						MusicTimer[client]=INVALID_HANDLE;
 					}
-					return Plugin_Stop;
 				}
+				continue;
 			}
 
 			if(MusicTimer[client]!=INVALID_HANDLE)

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -1540,7 +1540,7 @@ public DisableFF2()
 			}
 		}
 
-		if(MusicTimer[client])
+		if(MusicTimer[client]!=INVALID_HANDLE)
 		{
 			KillTimer(MusicTimer[client]);
 			MusicTimer[client]=INVALID_HANDLE;
@@ -2891,7 +2891,7 @@ public Action:Timer_PrepareBGM(Handle:timer, any:userid)
 				}
 				else
 				{
-					if(MusicTimer[client])
+					if(MusicTimer[client]!=INVALID_HANDLE)
 					{
 						KillTimer(MusicTimer[client]);
 						MusicTimer[client]=INVALID_HANDLE;
@@ -2900,7 +2900,7 @@ public Action:Timer_PrepareBGM(Handle:timer, any:userid)
 				continue;
 			}
 
-			if(MusicTimer[client])
+			if(MusicTimer[client]!=INVALID_HANDLE)
 			{
 				KillTimer(MusicTimer[client]);
 				MusicTimer[client]=INVALID_HANDLE;
@@ -2915,7 +2915,7 @@ public Action:Timer_PrepareBGM(Handle:timer, any:userid)
 		}
 		else
 		{
-			if(MusicTimer[client])
+			if(MusicTimer[client]!=INVALID_HANDLE)
 			{
 				KillTimer(MusicTimer[client]);
 				MusicTimer[client]=INVALID_HANDLE;
@@ -3016,7 +3016,7 @@ StopMusic(client=0, bool:permanent=false)
 				StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 			}
 
-			if(MusicTimer[client])
+			if(MusicTimer[client]!=INVALID_HANDLE)
 			{
 				KillTimer(MusicTimer[client]);
 				MusicTimer[client]=INVALID_HANDLE;
@@ -3033,7 +3033,7 @@ StopMusic(client=0, bool:permanent=false)
 		StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 		StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 
-		if(MusicTimer[client])
+		if(MusicTimer[client]!=INVALID_HANDLE)
 		{
 			KillTimer(MusicTimer[client]);
 			MusicTimer[client]=INVALID_HANDLE;


### PR DESCRIPTION
(My English is bad. sorry :(.. )

Yeah. BGM doesn't loop when called Timer_PrepareBGM with 0.
(Like this. `CreateTimer(0.0, Timer_PrepareBGM, 0, TIMER_FLAG_NO_MAPCHANGE);`)

when called `PlayBGM(client)` then `MusicTimer[client]` will be NOT INVALID_HANDLE.
But it will be INVALID_HANDLE. 

Because 
```
if(MusicTimer[client]!=INVALID_HANDLE)
{
	KillTimer(MusicTimer[client]);
	MusicTimer[client]=INVALID_HANDLE;
}
```
(On next if)
Yep. Thanks for reading this. x3 
