### PR TITLE
Fix #405

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -3014,16 +3014,13 @@ StopMusic(client=0, bool:permanent=false)
 			{
 				StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 				StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
-			}
 
-			if(MusicTimer[client]!=INVALID_HANDLE)
-			{
-				KillTimer(MusicTimer[client]);
-				MusicTimer[client]=INVALID_HANDLE;
-			}
+				if(MusicTimer[client])
+				{
+					KillTimer(MusicTimer[client]);
+					MusicTimer[client]=INVALID_HANDLE;
+				}
 
-			if(!StrEqual(currentBGM[client], "ff2_stop_music"))
-			{
 				strcopy(currentBGM[client], PLATFORM_MAX_PATH, !permanent ? "" : "ff2_stop_music");
 			}
 		}
@@ -3033,16 +3030,13 @@ StopMusic(client=0, bool:permanent=false)
 		StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 		StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 
-		if(MusicTimer[client]!=INVALID_HANDLE)
+		if(MusicTimer[client])
 		{
 			KillTimer(MusicTimer[client]);
 			MusicTimer[client]=INVALID_HANDLE;
 		}
 
-		if(!StrEqual(currentBGM[client], "ff2_stop_music"))
-		{
-			strcopy(currentBGM[client], PLATFORM_MAX_PATH, !permanent ? "" : "ff2_stop_music");
-		}
+		strcopy(currentBGM[client], PLATFORM_MAX_PATH, !permanent ? "" : "ff2_stop_music");
 	}
 }
 


### PR DESCRIPTION
This was the culprit of #405 

```
		if(!StrEqual(currentBGM[client], "ff2_stop_music"))
		{
			strcopy(currentBGM[client], PLATFORM_MAX_PATH, !permanent ? "" : "ff2_stop_music");
		}
```

Fixed it by removing the !StrEqual if check and leaving strcopy do its job.
```
		strcopy(currentBGM[client], PLATFORM_MAX_PATH, !permanent ? "" : "ff2_stop_music");
```