### PR TITLE
Fixed FF2 Stop Music Staying Off (But Broke ff2_start_music

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2996,11 +2996,13 @@ StartMusic(client=0)
 	{
 		StopMusic();
 		CreateTimer(0.0, Timer_PrepareBGM, 0, TIMER_FLAG_NO_MAPCHANGE);
+		SetClientSoundOptions(client, SOUNDEXCEPT_MUSIC, true);
 	}
 	else
 	{
 		StopMusic(client);
 		CreateTimer(0.0, Timer_PrepareBGM, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
+		SetClientSoundOptions(client, SOUNDEXCEPT_MUSIC, true);
 	}
 }
 
@@ -3014,6 +3016,7 @@ StopMusic(client=0, bool:permanent=false)
 			{
 				StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 				StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
+				SetClientSoundOptions(client, SOUNDEXCEPT_MUSIC, false);
 
 				if(MusicTimer[client])
 				{
@@ -3029,6 +3032,7 @@ StopMusic(client=0, bool:permanent=false)
 	{
 		StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
 		StopSound(client, SNDCHAN_AUTO, currentBGM[client]);
+		SetClientSoundOptions(client, SOUNDEXCEPT_MUSIC, false);
 
 		if(MusicTimer[client]!=INVALID_HANDLE)
 		{


### PR DESCRIPTION
I managed to fix ff2_stop_music remaining off for all rounds until you manually do ff2_start_music sadly the commit i added broke ff2_start_music