### PR TITLE
Update health on round start

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2903,6 +2903,16 @@ public Action:StartBossTimer(Handle:timer)
 			CreateTimer(0.15, MakeNotBoss, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);  //TODO:  Is this needed?
 		}
 	}
+	
+	for(new boss; boss<=MaxClients; boss++)
+	{
+		if(IsValidClient(Boss[boss]) && IsPlayerAlive(Boss[boss]))
+		{
+			BossHealthMax[boss]=ParseFormula(boss, "health_formula", "(((760.8+n)*(n-1))^1.0341)+2046", RoundFloat(Pow((760.8+float(playing))*(float(playing)-1.0), 1.0341)+2046.0));
+			BossHealth[boss]=BossHealthMax[boss]*BossLivesMax[boss];
+			BossHealthLast[boss]=BossHealth[boss];
+		}
+	}
 
 	CreateTimer(0.2, BossTimer, _, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 	CreateTimer(0.2, CheckAlivePlayers, _, TIMER_FLAG_NO_MAPCHANGE);


### PR DESCRIPTION
I notified you about this issue months ago. Today I saw this comment:

> Sadao
> Not sure if this is a unfixable bug but , whenever you start the round as a hale , and theres less people ( the other people is gonna join in a few seconds ) But yet you still start with a very low hp against 19 people , why does that happen? ( example : gentlespy starts with 6024 hp vs 19 people ) i think its really unfair and a disadvantage for every hale.

This pull request fixes the mentioned issue.