### PR TITLE
Fixed non-uber but medigun can gain crit to target. 

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -4151,7 +4151,7 @@ public Action:OnUberDeployed(Handle:event, const String:name[], bool:dontBroadca
 public Action:Timer_Uber(Handle:timer, any:medigunid)
 {
 	new medigun=EntRefToEntIndex(medigunid);
-	if(medigun && IsValidEntity(medigun) && CheckRoundState()==1)
+	if(medigun && IsValidEntity(medigun) && CheckRoundState()==1 && GetEntProp(medigun, Prop_Send, "m_bChargeRelease")>0)
 	{
 		new client=GetEntPropEnt(medigun, Prop_Send, "m_hOwnerEntity");
 		new Float:charge=GetEntPropFloat(medigun, Prop_Send, "m_flChargeLevel");


### PR DESCRIPTION
(English is still bad. Sorry :( )

https://youtu.be/caBHOkQ_lC4

Yeah. This video has uploaded (almost) 2 years ago. And it is custom version. But it was same code with this!! and it works at another FF2 server.  

before this commit, In `Timer_Uber`, before your medigun `m_flChargeLevel` is reached at `0.05`. Change weapon that has attribute  `add uber charge on hit`. (and `Timer_Uber' doesn't stop.)
and ubercharge is ended, hit enemy. then medigun can gain crit to target without ubercharge. 

So.. this commit is just stop `Timer_Uber' when ubercharge is ended.