### PR TITLE
Fix default_abilities not compiling under SM 1.9(and 1.8)

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/default_abilities.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/default_abilities.sp
@@ -231,7 +231,7 @@ Rage_Stun(const String:abilityName[], boss)
 					TF2_RemoveCondition(target, TFCond_Parachute);
 				}
 				TF2_StunPlayer(target, duration, 0.0, TF_STUNFLAGS_GHOSTSCARE|TF_STUNFLAG_NOSOUNDOREFFECT, client);
-				CreateTimer(duration, RemoveEntity, EntIndexToEntRef(AttachParticle(target, "yikes_fx", 75.0)), TIMER_FLAG_NO_MAPCHANGE);
+				CreateTimer(duration, RemoveObject, EntIndexToEntRef(AttachParticle(target, "yikes_fx", 75.0)), TIMER_FLAG_NO_MAPCHANGE);
 			}
 		}
 	}
@@ -257,7 +257,7 @@ Rage_StunSentry(const String:abilityName[], boss)
 		if(GetVectorDistance(bossPosition, sentryPosition)<=distance)
 		{
 			SetEntProp(sentry, Prop_Send, "m_bDisabled", 1);
-			CreateTimer(duration, RemoveEntity, EntIndexToEntRef(AttachParticle(sentry, "yikes_fx", 75.0)), TIMER_FLAG_NO_MAPCHANGE);
+			CreateTimer(duration, RemoveObject, EntIndexToEntRef(AttachParticle(sentry, "yikes_fx", 75.0)), TIMER_FLAG_NO_MAPCHANGE);
 			CreateTimer(duration, Timer_EnableSentry, EntIndexToEntRef(sentry), TIMER_FLAG_NO_MAPCHANGE);
 		}
 	}
@@ -447,8 +447,8 @@ Charge_Teleport(const String:abilityName[], boss, slot, status)
 			FF2_GetAbilityArgumentString(boss, PLUGIN_NAME, abilityName, "particle", particle, sizeof(particle));
 			if(strlen(particle)>0)
 			{
-				CreateTimer(3.0, RemoveEntity, EntIndexToEntRef(AttachParticle(client, particle)), TIMER_FLAG_NO_MAPCHANGE);
-				CreateTimer(3.0, RemoveEntity, EntIndexToEntRef(AttachParticle(client, particle, _, false)), TIMER_FLAG_NO_MAPCHANGE);
+				CreateTimer(3.0, RemoveObject, EntIndexToEntRef(AttachParticle(client, particle)), TIMER_FLAG_NO_MAPCHANGE);
+				CreateTimer(3.0, RemoveObject, EntIndexToEntRef(AttachParticle(client, particle, _, false)), TIMER_FLAG_NO_MAPCHANGE);
 			}
 
 			new Float:position[3];
@@ -473,8 +473,8 @@ Charge_Teleport(const String:abilityName[], boss, slot, status)
 				TeleportEntity(client, position, NULL_VECTOR, NULL_VECTOR);
 				if(strlen(particle)>0)
 				{
-					CreateTimer(3.0, RemoveEntity, EntIndexToEntRef(AttachParticle(client, particle)), TIMER_FLAG_NO_MAPCHANGE);
-					CreateTimer(3.0, RemoveEntity, EntIndexToEntRef(AttachParticle(client, particle, _, false)), TIMER_FLAG_NO_MAPCHANGE);
+					CreateTimer(3.0, RemoveObject, EntIndexToEntRef(AttachParticle(client, particle)), TIMER_FLAG_NO_MAPCHANGE);
+					CreateTimer(3.0, RemoveObject, EntIndexToEntRef(AttachParticle(client, particle, _, false)), TIMER_FLAG_NO_MAPCHANGE);
 				}
 			}
 
@@ -624,7 +624,7 @@ DissolveRagdoll(ragdoll)
 	AcceptEntityInput(dissolver, "Kill");
 }
 
-public Action:RemoveEntity(Handle:timer, any:entid)
+public Action:RemoveObject(Handle:timer, any:entid)
 {
 	new entity=EntRefToEntIndex(entid);
 	if(IsValidEntity(entity) && entity>MaxClients)


### PR DESCRIPTION
I was under the impression that i already made the changes in the FF2 repo. Now RemoveEntity() function is part of the Sourcemod API. Why not Add Timer_ prefix in front of every Timer callback?