### PR TITLE
Companion Toggle and Other Things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
     - wget "https://bitbucket.org/GoD_Tony/updater/raw/default/include/updater.inc" -O include/updater.inc
     - wget "https://raw.githubusercontent.com/Flyflo/SM-Goomba-Stomp/master/addons/sourcemod/scripting/include/goomba.inc" -O include/goomba.inc
     - wget "https://forums.alliedmods.net/attachment.php?attachmentid=115795&d=1360508618" -O include/rtd.inc
+    - wget "https://raw.githubusercontent.com/Phil25/RTD/master/scripting/include/rtd2.inc" -O include/rtd2.inc
     - wget "https://forums.alliedmods.net/attachment.php?attachmentid=116849&d=1377667508" -O include/tf2attributes.inc
 
     # RTD is particularly annoying since it doesn't handle optional plugin dependencies correctly

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -5440,12 +5440,12 @@ public Action:OnPlayerDeath(Handle:event, const String:eventName[], bool:dontBro
 			if(RedAlivePlayers!=1 && KSpreeCount[boss]!=3)  //Don't conflict with end-of-round sounds or killing spree
 			{
 				ClassKill=GetRandomInt(0, 2);
-				if((ClassKill == 1) && RandomSound("sound_hit", sound, sizeof(sound), boss))
+				if((ClassKill==1) && RandomSound("sound_hit", sound, sizeof(sound), boss))
 				{
 					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 				}
-				else if(ClassKill == 2)
+				else if(ClassKill==2)
 				{
 					new String:classnames[][]={"", "scout", "sniper", "soldier", "demoman", "medic", "heavy", "pyro", "spy", "engineer"};
 					decl String:class[32];

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -7903,11 +7903,11 @@ public FF2PanelH(Handle:menu, MenuAction:action, client, selection)
 			}
 			case 7:
 			{
-				CompanionTogglePanel(client);
+				HelpPanel3(client);
 			}
 			case 8:
 			{
-				HelpPanel3(client);
+				CompanionTogglePanel(client);
 			}
 			default:
 			{
@@ -7940,10 +7940,13 @@ public Action:FF2Panel(client, args)  //._.
 		DrawPanelItem(panel, text);
 		Format(text, sizeof(text), "%t", "menu_9");  //Toggle monologues (/ff2voice)
 		DrawPanelItem(panel, text);
-		Format(text, sizeof(text), "%t", "menu_10");  //Toggle companions (/ff2companion)
-		DrawPanelItem(panel, text);
 		Format(text, sizeof(text), "%t", "menu_9a");  //Toggle info about changes of classes in FF2
 		DrawPanelItem(panel, text);
+		if(GetConVarBool(cvarDuoToggle))
+		{
+			Format(text, sizeof(text), "%t", "menu_10");  //Toggle companions (/ff2companion)
+			DrawPanelItem(panel, text);
+		}
 		Format(text, sizeof(text), "%t", "menu_6");  //Exit
 		DrawPanelItem(panel, text);
 		SendPanelToClient(panel, client, FF2PanelH, MENU_TIME_FOREVER);

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -5862,7 +5862,6 @@ public Action:OnPlayerHurt(Handle:event, const String:name[], bool:dontBroadcast
 			{
 				if(IsValidClient(target) && !(FF2flags[target] & FF2FLAG_HUDDISABLED))
 				{
-					SetGlobalTransTarget(target);
 					PrintCenterText(target, "%t", ability, bossName, BossLives[boss]);
 				}
 			}
@@ -9048,7 +9047,7 @@ public OnItemSpawned(entity)
 
 public Action:OnPickup(entity, client)  //Thanks friagram!
 {
-	if(IsBoss(client))
+	if(IsBoss(client) && Enabled)
 	{
 		decl String:classname[32];
 		GetEntityClassname(entity, classname, sizeof(classname));

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -4273,13 +4273,13 @@ public CompanionTogglePanelH(Handle:menu, MenuAction:action, client, selection)
 		if(selection==2)
 		{
 			SetClientPreferences(client, TOGGLE_COMPANION, false);
+			CPrintToChat(client, "{olive}[FF2]{default} %t", "ff2_companion_off");
 		}
 		else
 		{
 			SetClientPreferences(client, TOGGLE_COMPANION, true);
+			CPrintToChat(client, "{olive}[FF2]{default} %t", "ff2_companion_on");
 		}
-
-		CPrintToChat(client, "{olive}[FF2]{default} %t", "ff2_companion", selection==2 ? "off" : "on");
 	}
 }
 

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -53,6 +53,7 @@ Updated by Wliu, Chris, Lawd, and Carge after Powerlord quit FF2
 
 #define SOUNDEXCEPT_MUSIC 0
 #define SOUNDEXCEPT_VOICE 1
+#define TOGGLE_COMPANION 2
 
 #define HEALTHBAR_CLASS "monster_resource"
 #define HEALTHBAR_PROPERTY "m_iBossHealthPercentageByte"
@@ -1241,8 +1242,8 @@ public OnPluginStart()
 	RegConsoleCmd("ff2_voice", VoiceTogglePanelCmd);
 	RegConsoleCmd("ff2_resetpoints", ResetQueuePointsCmd);
 	RegConsoleCmd("ff2resetpoints", ResetQueuePointsCmd);
-	RegConsoleCmd("ff2_companion", CompanionCmd);
-	RegConsoleCmd("ff2companion", CompanionCmd);
+	RegConsoleCmd("ff2_companion", CompanionToggleCmd);
+	RegConsoleCmd("ff2companion", CompanionToggleCmd);
 
 	RegConsoleCmd("hale", FF2Panel);
 	RegConsoleCmd("hale_hp", Command_GetHPCmd);
@@ -1259,8 +1260,8 @@ public OnPluginStart()
 	RegConsoleCmd("hale_voice", VoiceTogglePanelCmd);
 	RegConsoleCmd("hale_resetpoints", ResetQueuePointsCmd);
 	RegConsoleCmd("haleresetpoints", ResetQueuePointsCmd);
-	RegConsoleCmd("hale_companion", CompanionCmd);
-	RegConsoleCmd("halecompanion", CompanionCmd);
+	RegConsoleCmd("hale_companion", CompanionToggleCmd);
+	RegConsoleCmd("halecompanion", CompanionToggleCmd);
 
 	RegConsoleCmd("nextmap", Command_Nextmap);
 	RegConsoleCmd("say", Command_Say);
@@ -6891,7 +6892,7 @@ stock GetClientWithCompanionToggle(bool:omit[])
 	decl String:cookieValues[8][5];
 	for(new client=1; client<=MaxClients; client++)
 	{
-		if(IsValidClient(client) && GetClientQueuePoints(client)>=GetClientQueuePoints(winner) && !omit[client])
+		if(IsValidClient(client) && GetClientQueuePoints(client)>=GetClientQueuePoints(companion) && !omit[client])
 		{
 			if(!IsFakeClient(client) && AreClientCookiesCached(client) && GetConVarBool(cvarDuoToggle)) // Skip clients who have disabled being able to be selected as a companion
 			{
@@ -6914,7 +6915,7 @@ stock GetClientWithCompanionToggle(bool:omit[])
 	{
 		for(new client=1; client<MaxClients; client++)
 		{
-			if(IsValidClient(client) && GetClientQueuePoints(client)>=GetClientQueuePoints(winner) && !omit[client])
+			if(IsValidClient(client) && GetClientQueuePoints(client)>=GetClientQueuePoints(companion) && !omit[client])
 			{
 				if(SpecForceBoss || GetClientTeam(client)>_:TFTeam_Spectator) // Ignore the companion toggle pref if we can't find available clients
 				{

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -1242,8 +1242,8 @@ public OnPluginStart()
 	RegConsoleCmd("ff2_voice", VoiceTogglePanelCmd);
 	RegConsoleCmd("ff2_resetpoints", ResetQueuePointsCmd);
 	RegConsoleCmd("ff2resetpoints", ResetQueuePointsCmd);
-	RegConsoleCmd("ff2_companion", CompanionToggleCmd);
-	RegConsoleCmd("ff2companion", CompanionToggleCmd);
+	RegConsoleCmd("ff2_companion", CompanionTogglePanelCmd);
+	RegConsoleCmd("ff2companion", CompanionTogglePanelCmd);
 
 	RegConsoleCmd("hale", FF2Panel);
 	RegConsoleCmd("hale_hp", Command_GetHPCmd);
@@ -1260,8 +1260,8 @@ public OnPluginStart()
 	RegConsoleCmd("hale_voice", VoiceTogglePanelCmd);
 	RegConsoleCmd("hale_resetpoints", ResetQueuePointsCmd);
 	RegConsoleCmd("haleresetpoints", ResetQueuePointsCmd);
-	RegConsoleCmd("hale_companion", CompanionToggleCmd);
-	RegConsoleCmd("halecompanion", CompanionToggleCmd);
+	RegConsoleCmd("hale_companion", CompanionTogglePanelCmd);
+	RegConsoleCmd("halecompanion", CompanionTogglePanelCmd);
 
 	RegConsoleCmd("nextmap", Command_Nextmap);
 	RegConsoleCmd("say", Command_Say);
@@ -4240,7 +4240,18 @@ public Action:Timer_Uber(Handle:timer, any:medigunid)
 	return Plugin_Continue;
 }
 
-public Action:CompanionToggleCmd(client)
+public Action:CompanionTogglePanelCmd(client, args)
+{
+	if(!IsValidClient(client) || !GetConVarBool(cvarDuoToggle))
+	{
+		return Plugin_Continue;
+	}
+
+	CompanionTogglePanel(client);
+	return Plugin_Handled;
+}
+
+public Action:CompanionTogglePanel(client)
 {
 	if(!Enabled || !IsValidClient(client) || !GetConVarBool(cvarDuoToggle))
 	{
@@ -4251,12 +4262,12 @@ public Action:CompanionToggleCmd(client)
 	SetPanelTitle(panel, "Toggle being a Freak Fortress 2 companion...");
 	DrawPanelItem(panel, "On");
 	DrawPanelItem(panel, "Off");
-	SendPanelToClient(panel, client, CompanionToggleCmdH, MENU_TIME_FOREVER);
+	SendPanelToClient(panel, client, CompanionTogglePanelH, MENU_TIME_FOREVER);
 	CloseHandle(panel);
 	return Plugin_Continue;
 }
 
-public CompanionToogleCmdH(Handle:menu, MenuAction:action, client, selection)
+public CompanionTogglePanelH(Handle:menu, MenuAction:action, client, selection)
 {
 	if(IsValidClient(client) && action==MenuAction_Select)
 	{
@@ -7894,7 +7905,7 @@ public FF2PanelH(Handle:menu, MenuAction:action, client, selection)
 			}
 			case 7:
 			{
-				CompanionToggleCmd(client);
+				CompanionTogglePanel(client);
 			}
 			case 8:
 			{

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -80,6 +80,7 @@ new healthcheckused;
 new RedAlivePlayers;
 new BlueAlivePlayers;
 new RoundCount;
+new ClassKill=0;
 new Special[MAXPLAYERS+1];
 new Incoming[MAXPLAYERS+1];
 
@@ -2691,8 +2692,8 @@ public Action:OnRoundEnd(Handle:event, const String:name[], bool:dontBroadcast)
 
 		if(!bossWin && RandomSound("sound_fail", sound, sizeof(sound), boss))
 		{
-			EmitSoundToAll(sound);
-			EmitSoundToAll(sound);
+			EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+			EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 		}
 	}
 
@@ -2875,8 +2876,8 @@ public Action:StartResponseTimer(Handle:timer)
 	decl String:sound[PLATFORM_MAX_PATH];
 	if(RandomSound("sound_begin", sound, sizeof(sound)))
 	{
-		EmitSoundToAll(sound);
-		EmitSoundToAll(sound);
+		EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+		EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 	}
 	return Plugin_Continue;
 }
@@ -3034,7 +3035,7 @@ PlayBGM(userid)
 			if(CheckSoundException(client, SOUNDEXCEPT_MUSIC))
 			{
 				strcopy(currentBGM[client], PLATFORM_MAX_PATH, music);
-				EmitSoundToClient(client, music);
+				ClientCommand(client, "playgamesound \"%s\"", music);
 				if(time>1)
 				{
 					MusicTimer[client]=CreateTimer(time, Timer_PrepareBGM, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
@@ -4133,8 +4134,8 @@ public Action:OnObjectDestroyed(Handle:event, const String:name[], bool:dontBroa
 			decl String:sound[PLATFORM_MAX_PATH];
 			if(RandomSound("sound_kill_buildable", sound, sizeof(sound)))
 			{
-				EmitSoundToAll(sound);
-				EmitSoundToAll(sound);
+				EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+				EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 			}
 		}
 	}
@@ -5430,30 +5431,32 @@ public Action:OnPlayerDeath(Handle:event, const String:eventName[], bool:dontBro
 			{
 				if(RandomSound("sound_first_blood", sound, sizeof(sound), boss))
 				{
-					EmitSoundToAll(sound);
-					EmitSoundToAll(sound);
+					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 				}
 				firstBlood=false;
 			}
 
-			if(RedAlivePlayers!=1)  //Don't conflict with end-of-round sounds
+			if(RedAlivePlayers!=1 && KSpreeCount[boss]!=3)  //Don't conflict with end-of-round sounds or killing spree
 			{
-				if(GetRandomInt(0, 1) && RandomSound("sound_hit", sound, sizeof(sound), boss))
+				ClassKill=GetRandomInt(0, 2);
+				if((ClassKill == 1) && RandomSound("sound_hit", sound, sizeof(sound), boss))
 				{
-					EmitSoundToAll(sound);
-					EmitSoundToAll(sound);
+					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 				}
-				else if(!GetRandomInt(0, 2))  //1/3 chance for "sound_kill_<class>"
+				else if(ClassKill == 2)
 				{
 					new String:classnames[][]={"", "scout", "sniper", "soldier", "demoman", "medic", "heavy", "pyro", "spy", "engineer"};
 					decl String:class[32];
 					Format(class, sizeof(class), "sound_kill_%s", classnames[TF2_GetPlayerClass(client)]);
 					if(RandomSound(class, sound, sizeof(sound), boss))
 					{
-						EmitSoundToAll(sound);
-						EmitSoundToAll(sound);
+						EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+						EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 					}
 				}
+				ClassKill=0;
 			}
 
 			if(GetGameTime()<=KSpreeTimer[boss])
@@ -5469,8 +5472,8 @@ public Action:OnPlayerDeath(Handle:event, const String:eventName[], bool:dontBro
 			{
 				if(RandomSound("sound_kspree", sound, sizeof(sound), boss))
 				{
-					EmitSoundToAll(sound);
-					EmitSoundToAll(sound);
+					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 				}
 				KSpreeCount[boss]=0;
 			}
@@ -5490,8 +5493,8 @@ public Action:OnPlayerDeath(Handle:event, const String:eventName[], bool:dontBro
 
 		if(RandomSound("sound_death", sound, sizeof(sound), boss))
 		{
-			EmitSoundToAll(sound);
-			EmitSoundToAll(sound);
+			EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+			EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 		}
 
 		BossHealth[boss]=0;
@@ -5627,8 +5630,8 @@ public Action:Timer_CheckAlivePlayers(Handle:timer)
 		decl String:sound[PLATFORM_MAX_PATH];
 		if(RandomSound("sound_lastman", sound, sizeof(sound)))
 		{
-			EmitSoundToAll(sound);
-			EmitSoundToAll(sound);
+			EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+			EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 		}
 	}
 	else if(!PointType && RedAlivePlayers<=AliveToEnable && !executed)
@@ -5867,13 +5870,13 @@ public Action:OnPlayerHurt(Handle:event, const String:name[], bool:dontBroadcast
 
 			if(BossLives[boss]==1 && RandomSound("sound_last_life", ability, sizeof(ability), boss))
 			{
-				EmitSoundToAll(ability);
-				EmitSoundToAll(ability);
+				EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, ability, _, _, _, _, _, _, _, _, _, false);
+				EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, ability, _, _, _, _, _, _, _, _, _, false);
 			}
 			else if(RandomSound("sound_nextlife", ability, sizeof(ability), boss))
 			{
-				EmitSoundToAll(ability);
-				EmitSoundToAll(ability);
+				EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, ability, _, _, _, _, _, _, _, _, _, false);
+				EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, ability, _, _, _, _, _, _, _, _, _, false);
 			}
 
 			UpdateHealthBar();
@@ -6232,6 +6235,13 @@ public Action:OnTakeDamage(client, &attacker, &inflictor, &Float:damage, &damage
 
 							EmitSoundToClient(attacker, "player/doubledonk.wav", _, _, _, _, 0.6, _, _, position, _, false);
 							EmitSoundToClient(client, "player/doubledonk.wav", _, _, _, _, 0.6, _, _, position, _, false);
+
+							decl String:sound[PLATFORM_MAX_PATH];
+							if(RandomSound("sound_marketed", sound, sizeof(sound)))
+							{
+								EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+								EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+							}
 							return Plugin_Changed;
 						}
 					}
@@ -6419,6 +6429,13 @@ public Action:OnTakeDamage(client, &attacker, &inflictor, &Float:damage, &damage
 					if(!(FF2flags[client] & FF2FLAG_HUDDISABLED))
 					{
 						PrintHintText(client, "%t", "Telefragged");
+					}
+
+					decl String:sound[PLATFORM_MAX_PATH];
+					if(RandomSound("sound_telefraged", sound, sizeof(sound)))
+					{
+						EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+						EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 					}
 					return Plugin_Changed;
 				}

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -82,7 +82,6 @@ new healthcheckused;
 new RedAlivePlayers;
 new BlueAlivePlayers;
 new RoundCount;
-new ClassKill=0;
 new Special[MAXPLAYERS+1];
 new Incoming[MAXPLAYERS+1];
 
@@ -5515,7 +5514,7 @@ public Action:OnPlayerDeath(Handle:event, const String:eventName[], bool:dontBro
 
 			if(RedAlivePlayers!=1 && KSpreeCount[boss]!=3)  //Don't conflict with end-of-round sounds or killing spree
 			{
-				ClassKill=GetRandomInt(0, 2);
+				new ClassKill=GetRandomInt(0, 2);
 				if((ClassKill==1) && RandomSound("sound_hit", sound, sizeof(sound), boss))
 				{
 					EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
@@ -5532,7 +5531,6 @@ public Action:OnPlayerDeath(Handle:event, const String:eventName[], bool:dontBro
 						EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
 					}
 				}
-				ClassKill=0;
 			}
 
 			if(GetGameTime()<=KSpreeTimer[boss])

--- a/addons/sourcemod/translations/freak_fortress_2.phrases.txt
+++ b/addons/sourcemod/translations/freak_fortress_2.phrases.txt
@@ -277,10 +277,13 @@
 		"#format" "{1:s}"
 		"en"	"FF2 monologues: {1}."
 	}
-	"ff2_companion"
+	"ff2_companion_on"
 	{
-		"#format" "{1:s}"
-		"en"	"FF2 Companions: {1}"
+		"en"	"You can be selected as companion"
+	}
+	"ff2_companion_off"
+	{
+		"en"	"You won't be selected as companion"
 	}
 	"ff2_voice2"
 	{

--- a/addons/sourcemod/translations/freak_fortress_2.phrases.txt
+++ b/addons/sourcemod/translations/freak_fortress_2.phrases.txt
@@ -277,6 +277,11 @@
 		"#format" "{1:s}"
 		"en"	"FF2 monologues: {1}."
 	}
+	"ff2_companion"
+	{
+		"#format" "{1:s}"
+		"en"	"FF2 Companions: {1}"
+	}
 	"ff2_voice2"
 	{
 		"en"	"Other sounds will be playing, but very quietly."
@@ -292,6 +297,10 @@
 	"menu_9a"
 	{
 		"en"	"Toggle info about changes of classes in FF2"
+	}
+	"menu_10"
+	{
+		"en"	"Toggle companions (/ff2companion)"
 	}
 	"ff2_classinfo"
 	{


### PR DESCRIPTION
I have my Unofficial version of FF2's companion toggle into Official. I changed it so it works will the standard FF2 cookie system. It is also possible for server owners to disable players being able to toggle being a companion.
Other things include:
* RTD2 compatibility
* Improvements to vocal toggle
* BGMs use playgamesound instead of EmitSound
* Changes to when sound_hit and sound_kill_class plays
* Added sound_marketed and sound_telefraged
* Pickups when FF2 is disabled