### PR TITLE
Remove RTD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,6 @@ It is highly recommended that you also make these changes when compiling FF2.
 MarkNativeAsOptional("SMAC_CheatDetected");
 ```
 
-`rtd.inc`:  Inside `public SharedPlugin:__pl_rtd = `
-* Remove:
-```sourcepawn
-required = 1
-```
-* Add:
-```sourcepawn
-#if defined REQUIRE_PLUGIN
-required = 1
-#else
-required = 0
-#endif
-```
 
 ### Formatting
 ***


### PR DESCRIPTION
RTD 0.4 is dead, anyway, include are not needed, since forward is used to block effects for bosses.